### PR TITLE
Feature limit ohtml scope

### DIFF
--- a/Lib/Log.ahk
+++ b/Lib/Log.ahk
@@ -76,6 +76,7 @@ Used Personal Fork        : `%bUseOwnOHTMLFork`%
 Verbosity                 : `%bVerboseCheckbox`%
 Stripped OHTML - Errors   : `%bRemoveObsidianHTMLErrors`%
 Stripped Local MD-Links   : `%bStripLocalMarkdownLinks`%
+Vault Limited             : `%bRestrictOHTMLScope`%
 
 RMD:
 Render to Outputs         : `%bRenderRMD`%
@@ -95,6 +96,8 @@ RMarkdown Document Settings:
 ___________________________________________________
 Paths:
 manuscriptlocation        : `%manuscriptpath`%
+Vault limited to childs of: `%temporaryVaultpath`%
+Vault-Limiter removed     : `%temporaryVaultpathRemoved`%
 Output Folder             : `%output_path`%
 Raw Input Copy            : `%rawInputcopyLocation`%
 ObsidianHTML - Path       : `%obsidianHTML_path`% (either the path to the installed exe or the personal modded version)

--- a/Lib/ObsidianHTML.ahk
+++ b/Lib/ObsidianHTML.ahk
@@ -1,4 +1,4 @@
-﻿ObsidianHtml(manuscript_path:="",config_path:="",bUseConvert:=true,bUseOwnOHTMLFork:=false,bVerbose:=false,WD="",WorkDir:="",WorkDir_OwnFork:="") {
+﻿ObsidianHtml(manuscript_path:="",config_path:="",bUseConvert:=true,bUseOwnOHTMLFork:=false,bVerbose:=false,WD="",WorkDir:="",WorkDir_OwnFork:="",ScopeRestrictorObject:="") {
 
     if (WorkDir="") {
         WorkDir:= A_Desktop "\ObsidianHTMLOutput"
@@ -63,6 +63,9 @@
         IfMsgBox Yes, {
 
         } Else IfMsgBox No, {
+            if (FileExist(ScopeRestrictorObject.Path) && !ScopeRestrictorObject.IsVaultRoot) {
+                FileRemoveDir % ScopeRestrictorObject.Path
+            }
             reload
         }
     }

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -1,0 +1,257 @@
+createTemporaryObsidianVaultRoot(manuscript_location) {
+    ;manuscript_location := A_ScriptDir "\Obsidian NoteTaking\The Universe\200 University\06 Interns and Unis\BE28 Internship Report\Submission\BE28 Internship Report.md"
+    Graph:=findObsidianVaultRootFromNote(manuscript_location,true)
+    TV_String:=AssembleTV_String(Graph[2])
+    ret:=chooseTV_Element(TV_String,Graph)
+    ;ret2:=removeTemporaryObsidianVaultRoot(ret.Path,Graph)
+    return {IsVaultRoot:ret.IsVaultRoot,Path:ret.Path,Graph:Graph}
+}
+
+ExitApp 
+/*
+1. TV:=getManuscriptDirectory(manuscript_path)
+2. Path:=chooseTV_Element(TV)
+3. REMOVEFLAG:=checkTemporaryObsidianVaultLocation(Path)
+TRUE: will be removed
+FALSE: will not be removed
+4. check if FileExist(Path)
+- FALSE: create `.obsidian`-folder at `Path`-Location
+- TRUE: go on
+5. IF REMOVEFLAG==TRUE:: set onexit cleanup which removes the temporary `.obsidian`-folder -> removeTemporaryObsidianVaultRoot(Path)
+*/
+
+AssembleTV_String(Array) {
+    static str:="", reorder:={}
+    Loop, % Array.Count()
+    {
+        Val:=Array[Array.Count() + 1 - A_Index]
+        reorder.push(Val)
+        Indents:=A_Index
+        loop, %Indents%
+            str.= A_Tab
+        str.=Val "`tIcon4 expand`n"
+    }
+    OutputDebug % str
+    global reordered_arr:=reorder
+    return Str
+}
+findObsidianVaultRootFromNote(path,reset:=false) {
+    static FoundLocation:=OutFileName:=""
+    static arr:={}
+    OutputDebug % "`n"
+    path_orig:=path
+    if reset { ;; this is not relevant for now, but is needed for the GUI-implementation later on.
+        arr:={}
+    }
+    if (SubStr(path,0)="\") ;; remove "\" from folder path if present
+        path:=SubStr(path,1,StrLen(path)-1)
+
+    SplitPath % path,OutFileName, OutDir
+    OutputDebug % (InStr(FileExist(path),"D")?"Directory":"File")
+    if !InStr(FileExist(path),"D") { ;; path is a file, so use OutDir as path
+        path:=OutDir
+    }
+
+    obsidianVaultCheckString:=path "\.obsidian"
+    if !InStr(FileExist(path_orig),"D") { ;; path is a file, so use OutDir as path
+
+    } else {
+        Arr.push(OutFileName)
+    }
+    if InStr(FileExist(obsidianVaultCheckString),"D") { ;; check if path contains ".obsidian"-folder
+        OutputDebug % " found at`n" path
+        FoundLocation:=obsidianVaultCheckString
+        C:=Arr[Arr.MaxIndex()]
+        Cap:=OutDir "\" C
+        Arr[Arr.MaxIndex()]:=Cap
+        OutputDebug % "`n"
+        return [FoundLocation,Arr] ;; collect and return the whole stack so far, this is the last call.
+    } else {
+        OutputDebug % " not found at`n" path
+        SplitPath % path_orig,OFN,OD
+        if (path_orig=OD) {
+            return 0 ;; we have reached the disk's root, all further cals would only run towards the recursion limit. Better back out now and throw an error
+        }
+        return %A_ThisFunc%(OD)
+    }
+    return -2 ;; unreachable and just here for my own OCD sake
+}
+
+
+chooseTV_Element(TV_String,Graph) {
+    global
+    /*
+    1. render the TV_GUI (callback of main GUI or TV-subGUI, depending on implementation)
+    2. retrieves the selected TV-Element upon GUI submit
+    */
+    ImageListID := IL_Create(5)
+    Loop 5 {
+        IL_Add(ImageListID, "shell32.dll", A_Index)
+    }
+    arrc:=Graph[2].Count()
+    if (arrc>20) {
+        arrc:=20
+    }
+    arrc++
+
+    /*
+    TODO: split this out to conform to the scoping of 'DynamicObsidianVaultRoot.ahk'
+    - TODO: style this GUI, color, font size, positioning, parent hwnd etc pp
+    - TODO: give this GUI a a hwnd and guilabel, reformat the function names to be pr   e   eeeeoperly namespaced
+    - TODO: add Guiescape callbacks, add fallbacks for those callbacks (what to do if none provided? just go on without limitation, or do not allow if chosen in main gui or just return to main gui?)
+    TODO: add a checkbox on the main GUI to forego using this feature (must be checked to use it, default is unchecked or lastUsage)
+    - TODO: adjust the log-template to contain this path if assigned
+    - TODO: add th
+    */
+    gui TOVR: new
+    gui TOVR: +hwndTOVRGUI
+    gui add, text,, % "Vault root: " Graph[2,arrc-1] "`nFolder containing chosen note: " manuscript_location
+    Gui Add, TreeView, r%arrc% ImageList%ImageListID% checked w1200 r%arrc%
+    Gui Add, Button, Default w70 gsubmitConfigFolder, Submit Folder
+    ;Gui Add, Button, w70 yp xp+85 gLoadFile, Load File
+    ;Gui Add, Button, w70 yp xp+85 gSaveFile, Save File
+    Gui +OwnDialogs
+    TV_Delete()
+    CreateTreeView(TV_String)
+    gui show, w600 Autosize, % script.name  " - Set limiting '.obsidian'-folder"
+    WinWaitClose % script.name  " - Set limiting '.obsidian'-folder"
+    if (temporary_obsidianconfig_path=-1) {
+        ;; user chose the vault root, so do not flag for delete
+        return {Path:Graph[1],IsVaultRoot:True}
+    }
+    if (temporary_obsidianconfig_path="") {
+        ;; user closed the GUI
+        return {Path:Graph[1],IsVaultRoot:True}
+    }
+    ttip(FileExist(temporary_obsidianconfig_path))
+    ret:=checkTemporaryObsidianVaultLocation(temporary_obsidianconfig_path)
+    if !ret.isVaultRoot {
+        FileCreateDir % temporary_obsidianconfig_path "\"
+        if !FileExist(temporary_obsidianconfig_path) {
+            ;; throw error
+        }
+    } else {
+        return false
+    }
+    ttip(FileExist(temporary_obsidianconfig_path))
+    ;m(temporary_obsidianconfig_path)
+    return {Path:temporary_obsidianconfig_path,IsVaultRoot:false} 
+}
+setTemporaryObsidianVaultRoot(Path) {
+    /*
+    1. receives return of chooseTV_Element
+    2. this element signifies the path at which the `.obsidian`-folder is to be set
+    3. check if we are at a legitimate .obsidian-vault root -> by checking if checkTemporaryObsidianVaultLocation(Path)
+    3.1 TRUE: not a vault root
+    1. checks if it already exists
+    2. sets if not existent, skip otherwhise
+    3. flag for 'delete'
+    3.2 FALSE: we are at vault root
+    1. flag for 'no-delete' - it's a legitimate vault root after all
+    4. checks for existence,
+    returns true if exists
+    returns false if not exist
+    returns -1 if it exists and is a legitimate vault root that is not to be deleted
+    */
+
+}
+
+checkTemporaryObsidianVaultLocation(Path) {
+    bool:=false
+    /*
+    check if 'Path' is at a legitimate vault root
+    - in this case we do not want to remove the .obsidian-folder upon exit, so return false
+    - if not at vault root, return true as this is to be a temporary root folder
+    - be cautious, default assumption is to keep the folder
+    */
+    bool:=!!FileExist(Path)
+    return {Path:Path,IsVaultRoot:bool}
+}
+
+removeTemporaryObsidianVaultRoot(Path,Graph) {
+    /*
+    check CRT date to make sure this folder is not somehow the true vault root - overkill, but better be safe than REALLY sorry
+    */
+    if (Path=Graph[1]) {
+        return {Path:Path,IsVaultRoot:True,IsEmpty:false}
+    }
+    isEmpty:=true
+    Loop, Files, % Path "\*.*", FD ;; check if temporary obsidian folder contains any files - which it shouldn't
+    {
+        isEmpty:=false
+
+    }
+    if isEmpty { ;; remove if empty
+        if (Path!=Graph[1]) {
+
+            FileRemoveDir % Path
+        }
+    } else {
+        ;; TODO:  check if this is the vault root actually. If Yes, return as array {Path:Path,isVaultRoot:True}
+        return {Path:Path,IsVaultRoot:True}
+    }
+    bool:=!!FileExist(Path)
+    if bool  {
+        ;; throw error: temporary .obsidian-folder could not be removed.
+    }
+    return {Path:Path,IsVaultRoot:False,Removed:!bool}
+}
+submitConfigFolder() {
+    global
+    gui TOVR: submit,
+    arr:={}
+    ItemID := 0  ; Causes the loop's first iteration to start the search at the top of the tree.
+    Loop
+    {
+
+        idp:=TV_GetParent(ItemID)
+        idn:=TV_GetChild(ItemID)
+        TV_GetText(ItemText, idn)
+        ItemID := TV_GetNext(idn, "Checked")  ; Replace "Full" with "Checked" to find all checkmarked items.
+        TV_GetText(PathText, ItemID)
+        if (PathText!="") {
+            arr.push(pathText)
+        }
+        if not ItemID  ; No more items in tree.
+            break ;; BUG: checking two entries should always return the most nested, but it always only returns one line. is this line at fault?
+        if (A_Index>(Graph[1].Count() + Graph[2].Count())) {
+            break
+        }
+    }
+    /*
+    use the contents of reordered_arr and 'pathText' to rebuild the path we need
+    */
+    if RegexMatch(arr[arr.MaxIndex()], "\((?<Count>\d*)\)",v) {
+        temporary_obsidianconfig_path:=""
+        loop, % vCount {
+            temporary_obsidianconfig_path.=reordered_arr[A_Index] "\"
+        }
+    } else {
+        ;; throw error
+        gui TOVR: destroy
+        return temporary_obsidianconfig_path:=-1
+    }
+    temporary_obsidianconfig_path:=temporary_obsidianconfig_path "\.obsidian"
+    temporary_obsidianconfig_path:=RegexReplace(temporary_obsidianconfig_path,"\\{2,}","\")
+    ;m(temporary_obsidianconfig_path)
+    gui TOVR: destroy
+    return temporary_obsidianconfig_path
+}
+CreateTreeView(TreeViewDefinitionString) {	; by Learning one
+    IDs := {} 
+    Loop, parse, TreeViewDefinitionString, `n, `r
+    {
+        if A_LoopField is space
+            continue
+        Item := RTrim(A_LoopField, A_Space A_Tab), Item := LTrim(Item, A_Space), Level := 0
+        While (SubStr(Item,1,1) = A_Tab)
+            Level += 1,	Item := SubStr(Item, 2)
+        RegExMatch(Item, "([^`t]*)([`t]*)([^`t]*)", match)	; match1 = ItemName, match3 = Options
+        if (Level=0)
+            IDs["Level0"] := TV_Add("(" A_Index ") " match1, 0, match3)
+        else
+            IDs["Level" Level] := TV_Add("(" A_Index ") " match1, IDs["Level" Level-1], match3)
+    }
+}	; http://www.autohotkey.com/board/topic/92863-fu
+
+

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -100,7 +100,7 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
     - TODO: add th
     */
     gui TOVR: new
-    gui TOVR: +hwndTOVRGUI
+    gui TOVR: +hwndTOVRGUI +LabelTOVR
     gui add, text,, % "Vault root: " Graph[2,arrc-1] "`nFolder containing chosen note: " manuscript_location
     Gui Add, TreeView, r%arrc% ImageList%ImageListID% checked w1200 r%arrc%
     Gui Add, Button, Default w70 gsubmitConfigFolder, Submit Folder
@@ -137,7 +137,7 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
         return {Path:Graph[1],IsVaultRoot:True}
     }
     if (temporary_obsidianconfig_path="") {
-        ;; user closed the GUI
+        ;; user closed the GUI - use default, do not flag for delete
         return {Path:Graph[1],IsVaultRoot:True}
     }
     ttip(FileExist(temporary_obsidianconfig_path))
@@ -153,6 +153,10 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
     ttip(FileExist(temporary_obsidianconfig_path))
     ;m(temporary_obsidianconfig_path)
     return {Path:temporary_obsidianconfig_path,IsVaultRoot:false} 
+}
+TOVREscape() {
+    gui TOVR: destroy
+    return
 }
 setTemporaryObsidianVaultRoot(Path) {
     /*

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -100,7 +100,7 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
     gui TOVR: +hwndTOVRGUI +LabelTOVR
     gui add, text,, % "Vault root: " Graph[2,arrc-1] "`nFolder containing chosen note: " manuscript_location
     Gui Add, TreeView, r%arrc% ImageList%ImageListID% checked w1200 r%arrc%
-    Gui Add, Button, Default w70 gsubmitConfigFolder, Submit Folder
+    Gui Add, Button, Default w70 gsubmitConfigFolder, &Submit Folder
     Gui +OwnDialogs
     TV_Delete()
     if (Level) && (bAutoSubmitOTGUI) {

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -60,7 +60,11 @@ findObsidianVaultRootFromNote(path,reset:=false) {
         FoundLocation:=obsidianVaultCheckString
         C:=Arr[Arr.MaxIndex()]
         Cap:=OutDir "\" C
-        Arr[Arr.MaxIndex()]:=Cap
+        if (arr.Count()=0) {
+            arr.push(Cap)
+        } else {
+            arr[arr.MaxIndex()]:=Cap
+        }
         OutputDebug % "`n"
         return [FoundLocation,Arr] ;; collect and return the whole stack so far, this is the last call.
     } else {

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -1,11 +1,11 @@
 createTemporaryObsidianVaultRoot(manuscript_location,bAutoSubmitOTGUI) {
     if (bAutoSubmitOTGUI) {
-        if (script.config.Config.AutoRelativeLevel!="") && (script.config.Config.AutoRelativeLevel >0) {
-            Level:=script.config.Config.AutoRelativeLevel + 0
+        if (script.config.Config.defaultRelativeLevel!="") && (script.config.Config.defaultRelativeLevel >0) {
+            Level:=script.config.Config.defaultRelativeLevel + 0
         }
 
     } else {
-        Level:=0
+        Level:=script.config.Config.defaultRelativeLevel + 0
     }
     Graph:=findObsidianVaultRootFromNote(manuscript_location,true)
     TV_String:=AssembleTV_String(Graph[2])

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -1,9 +1,5 @@
 createTemporaryObsidianVaultRoot(manuscript_location,bAutoSubmitOTGUI) {
     if (bAutoSubmitOTGUI) {
-        /*
-        TODO: add option to autosubmit the GUI
-        TODO: add config setting to auto-defined the vault-root as the N-th level relative below the manuscriptlocation.
-        */
         if (script.config.Config.AutoRelativeLevel!="") && (script.config.Config.AutoRelativeLevel >0) {
             Level:=script.config.Config.AutoRelativeLevel + 0
         }
@@ -30,7 +26,7 @@ AssembleTV_String(Array) {
     }
     OutputDebug % str
     global reordered_arr:=reorder
-    return Str
+    return str
 }
 findObsidianVaultRootFromNote(path,reset:=false) {
     static FoundLocation:=OutFileName:=""
@@ -53,12 +49,12 @@ findObsidianVaultRootFromNote(path,reset:=false) {
     if !InStr(FileExist(path_orig),"D") { ;; path is a file, so use OutDir as path
 
     } else {
-        Arr.push(OutFileName)
+        arr.push(OutFileName)
     }
     if InStr(FileExist(obsidianVaultCheckString),"D") { ;; check if path contains ".obsidian"-folder
         OutputDebug % " found at`n" path
         FoundLocation:=obsidianVaultCheckString
-        C:=Arr[Arr.MaxIndex()]
+        C:=arr[arr.MaxIndex()]
         Cap:=OutDir "\" C
         if (arr.Count()=0) {
             arr.push(Cap)
@@ -66,10 +62,10 @@ findObsidianVaultRootFromNote(path,reset:=false) {
             arr[arr.MaxIndex()]:=Cap
         }
         OutputDebug % "`n"
-        return [FoundLocation,Arr] ;; collect and return the whole stack so far, this is the last call.
+        return [FoundLocation,arr] ;; collect and return the whole stack so far, this is the last call.
     } else {
         OutputDebug % " not found at`n" path
-        SplitPath % path_orig,OFN,OD
+        SplitPath % path_orig,,OD
         if (path_orig=OD) {
             return 0 ;; we have reached the disk's root, all further cals would only run towards the recursion limit. Better back out now and throw an error
         }
@@ -95,12 +91,9 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
     arrc++
 
     /*
-    TODO: split this out to conform to the scoping of 'DynamicObsidianVaultRoot.ahk'
     - TODO: style this GUI, color, font size, positioning, parent hwnd etc pp
     - TODO: give this GUI a a hwnd and guilabel, reformat the function names to be pr   e   eeeeoperly namespaced
-    - TODO: add Guiescape callbacks, add fallbacks for those callbacks (what to do if none provided? just go on without limitation, or do not allow if chosen in main gui or just return to main gui?)
     TODO: add a checkbox on the main GUI to forego using this feature (must be checked to use it, default is unchecked or lastUsage)
-    - TODO: adjust the log-template to contain this path if assigned
     - TODO: add th
     */
     gui TOVR: new
@@ -108,8 +101,6 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
     gui add, text,, % "Vault root: " Graph[2,arrc-1] "`nFolder containing chosen note: " manuscript_location
     Gui Add, TreeView, r%arrc% ImageList%ImageListID% checked w1200 r%arrc%
     Gui Add, Button, Default w70 gsubmitConfigFolder, Submit Folder
-    ;Gui Add, Button, w70 yp xp+85 gLoadFile, Load File
-    ;Gui Add, Button, w70 yp xp+85 gSaveFile, Save File
     Gui +OwnDialogs
     TV_Delete()
     if (Level) && (bAutoSubmitOTGUI) {
@@ -229,12 +220,10 @@ submitConfigFolder(Level:="") {
     Loop
     {
 
-        idp:=TV_GetParent(ItemID)
         idn:=TV_GetChild(ItemID)
-        TV_GetText(ItemText, idn)
         ItemID := TV_GetNext(idn, "Checked")  ; Replace "Full" with "Checked" to find all checkmarked items.
-        TV_GetText(PathText, ItemID)
-        if (PathText!="") {
+        TV_GetText(pathText, ItemID)
+        if (pathText!="") {
             arr.push(pathText)
         }
         if not ItemID  ; No more items in tree.

--- a/Lib/TemporaryObsidianVaultRoot.ahk
+++ b/Lib/TemporaryObsidianVaultRoot.ahk
@@ -120,8 +120,28 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
         TV_String:=strreplace(TV_String,"Icon4 expand","Icon4 expand Check1",,occurences)
         TV_String:=strreplace(TV_String,"Icon4 expand Check1","Icon 4")
     }
-    CreateTreeView(TV_String)
+    TVIDs:=CreateTreeView(TV_String)
+    if (Level) && !(bAutoSubmitOTGUI) {
+        loop, % TVIDs.Count() - Level {
+            Key:="Level" A_Index
+        }
+        for each, ID in TVIDs {
+            if (each=Key) {
+                r:=TV_Modify(ID,"Check") ;; check selected
+            } else {
+                r2:=TV_Modify(ID,"-Check") ;; uncheck the rest just in case
+            }
+        }
+    }
     gui show, w600 Autosize, % script.name  " - Set limiting '.obsidian'-folder"
+    objTOVRHK_Handler:=Func("TOVRHK_Handler").Bind(TVIDs)
+    Hotkey ifWinActive, % "ahk_id " TOVRGUI
+    loop, 9 {
+        Key:="^" A_Index-1
+        Hotkey % Key, % objTOVRHK_Handler
+    }
+    Hotkey ^m, % objTOVRHK_Handler
+    Hotkey IfWinActive
     if (Level) && (bAutoSubmitOTGUI) {
         submitConfigFolder()
     } else {
@@ -151,6 +171,34 @@ chooseTV_Element(TV_String,Graph,Level,bAutoSubmitOTGUI) {
 }
 TOVREscape() {
     gui TOVR: destroy
+    return
+}
+TOVRHK_Handler(TVIDs:="") {
+    /*
+    if Instr athishotkey, number
+    tvids entry at number
+    guicontrol check entry id
+    return
+    */
+    dfg:=A_DefaultGUI
+    gui TOVR: default
+    if RegexMatch(A_ThisHotkey,"(?<Count>\d+)",v) {
+        loop, % vCount {
+            Key:="Level" A_Index
+        }
+        for each, ID in TVIDs {
+            if (each=Key) {
+                r:=TV_Modify(ID,"Check") ;; check selected
+            } else {
+                r2:=TV_Modify(ID,"-Check") ;; uncheck the rest just in case
+            }
+        }
+        ;ID:=TVIDs[Key]
+        ;TV_Modify(ID,"Check") ;; recheck the intended oned
+    } else {
+
+    }
+    ;gui % dfg ":" default
     return
 }
 setTemporaryObsidianVaultRoot(Path) {
@@ -266,6 +314,7 @@ CreateTreeView(TreeViewDefinitionString) {	; by Learning one
         else
             IDs["Level" Level] := TV_Add("(" A_Index ") " match1, IDs["Level" Level-1], match3)
     }
+    return IDs
 }	; http://www.autohotkey.com/board/topic/92863-fu
 
 

--- a/ObsidianKnittr.ahk
+++ b/ObsidianKnittr.ahk
@@ -60,21 +60,27 @@ main() {
         InitialSettings=
             (LTrim
                 [Config]
-                bundleAHKRecompileStarter=0
+                backupCount=250
+                bundleAHKStarter=1
+                defaultRelativeLevel=2
                 Destination=0
+                FullLogOnSuccess=0
                 HistoryLimit=25
                 obsidianhtml_configfile=
-                obsidianTagEndChars=():´
+                obsidianTagEndChars=():'
+                OHTML_OutputDir=%A_Desktop%\TempTemporal\
                 OpenParentfolderInstead=1
                 RScriptPath=%given_rscriptpath%
                 searchroot=%given_searchroot%
                 SetSearchRootToLastRunManuscriptFolder=1
-                OHTML_OutputDir=%A_Desktop%\TempTemporal
                 [Version]
                 ObsidianHTML_Version=3.4.1
-                ObsidianKnittr_Version=2.1.3
+                ObsidianKnittr_Version=3.1.3
                 [LastRun]
+                BackupOutput=1
+                bStripLocalMarkdownLinks=0
                 Conversion=
+                ConvertInsteadofRun=1
                 ForceFixPNGFiles=0
                 FullLog=0
                 InsertSetupChunk=0
@@ -82,8 +88,11 @@ main() {
                 last_output_type=
                 manuscriptpath=
                 RemoveHashTagFromTags=1
-                RenderRMD=1
+                RemoveObsidianHTMLErrors=0
+                RenderRMD=0
+                RestrictOHTMLScope=0
                 UseCustomTOC=0
+                UseOwnOHTMLFork=0
                 Verbose=0
                 [GuiPositioning]
                 H=

--- a/ObsidianKnittr.ahk
+++ b/ObsidianKnittr.ahk
@@ -179,9 +179,9 @@ main() {
     }
 
     if (tmpconfig[1] && bConvertInsteadofRun) {
-        ret:=ObsidianHtml(,tmpconfig[1],,bUseOwnOHTMLFork,bVerboseCheckbox,OHTML_OutputDir,WorkDir,WorkDir_OwnFork)
+        ret:=ObsidianHtml(,tmpconfig[1],,bUseOwnOHTMLFork,bVerboseCheckbox,OHTML_OutputDir,WorkDir,WorkDir_OwnFork,OHTMLScopeRestrictor_Object)
     } else {
-        ret:=ObsidianHtml(manuscriptpath,tmpconfig[1],,bUseOwnOHTMLFork,bVerboseCheckbox,OHTML_OutputDir,WorkDir,WorkDir_OwnFork)
+        ret:=ObsidianHtml(manuscriptpath,tmpconfig[1],,bUseOwnOHTMLFork,bVerboseCheckbox,OHTML_OutputDir,WorkDir,WorkDir_OwnFork,OHTMLScopeRestrictor_Object)
     }
     if (bRestrictOHTMLScope) {
         tempOVaultRoot:=removeTemporaryObsidianVaultRoot(OHTMLScopeRestrictor_Object.Path,OHTMLScopeRestrictor_Object.Graph)

--- a/ObsidianKnittr.ahk
+++ b/ObsidianKnittr.ahk
@@ -103,7 +103,11 @@ main() {
     WorkDir := "C:\Users\Claudius Main\Desktop\TempTemporal"
     WorkDir_OwnFork := "D:\Dokumente neu\ObsidianPluginDev\obsidian-html"
     formats:=""
+    bAutoSubmitOTGUI:=false
     for _,format in out.Outputformats {
+        if format.SkipGUI {
+            bAutoSubmitOTGUI:=format.SkipGUI
+        }
         if format.HasKey("Error") && (format.Error.ID=0) {
             Reload
             ExitApp ;; fucking weird bug. DO NOT remove this exitapp below the reload-command. for some reason, removing it results in the script just ignoring the reload and continuing on as normal under certain situations
@@ -170,7 +174,8 @@ main() {
     Codetimer_Log()
     OHTML_OutputDir:=Deref(script.config.config.OHTML_OutputDir)
     if (bRestrictOHTMLScope) {
-        OHTMLScopeRestrictor_Object:=createTemporaryObsidianVaultRoot(manuscriptpath)
+
+        OHTMLScopeRestrictor_Object:=createTemporaryObsidianVaultRoot(manuscriptpath,bAutoSubmitOTGUI)
     }
 
     if (tmpconfig[1] && bConvertInsteadofRun) {


### PR DESCRIPTION
Allows creation of a temporary `.obsidian`-folder to limit the scope which is considered as the vaulf by ObsidianHTML, thus speeding up processing time significantly if all files and attachments are closer to the note's folder than the vault's root.

Note that commit 8f72153 introduces a dependency for all subsequent commits on this fork, as well as forks based beyond the merge of this PR.