### PR TITLE
Feature limitbackups

### DIFF
--- a/Lib/Outputbackup.ahk
+++ b/Lib/Outputbackup.ahk
@@ -28,14 +28,33 @@ backupOutput(Path, manuscriptName, out) {
         Output_Log_Dest:=BackupDirectory "\" MT "\" Name "_Log.txt"
         FileMove % Output_Log_Source, % Output_Log_Dest,1
     }
-    return
+    return BackupDirectory
 }
-limitBackups(Count) {
+limitBackups(BackupDirectory,Limit) {
+    backupCount:=0
+    Arr:={}
+    Loop, Files, % BackupDirectory "\*", D 
+    {
+        backupCount++
+        Arr[A_LoopFileName]:=A_LoopFileFullPath
+    }
+    Arr2:={}
+    for _, Path in Arr {
+        Arr2.push(Path)
+    }
+    if Arr2.Count()>Limit {
+        Diff:=Arr2.Count()-Limit
+        loop, % Diff {
+            FileRemoveDir % Arr2[A_Index] "\",% true
+        }
+
+    }
     /*
     1. get number of backup subfolders 
     2. if number greater 'Count', get the remainder
     3. Get the 'remainder' number of oldest subfolders and 'FileRemoveDir' them
     */
+    return
 }
 
 ; #region:FindFreeFileName() (1452864709)

--- a/ObsidianKnittr.ahk
+++ b/ObsidianKnittr.ahk
@@ -285,10 +285,10 @@ main() {
             ttip("Executing R-BuildScript",5)
         }
         if bBackupOutput {
-            backupOutput(rmd_Path,manuscriptName,out)
+            BackupDirectory:=backupOutput(rmd_Path,manuscriptName,out)
         }
         if script.config.config.backupCount {
-            limitBackups(script.config.config.backupCount)
+            limitBackups(BackupDirectory,script.config.config.backupCount)
         }
         Rdata_out:=runRScript(rmd_Path,script_contents,Outputformats,script.config.config.RScriptPath)
         EL.Rdata_out:=Rdata_out


### PR DESCRIPTION
Script will limit the number of backups to a set number, by default 250 copies. Only the compiled output files and the log file are backed up, the input note is not to save on storage. 